### PR TITLE
Add residual comparison popup

### DIFF
--- a/style.css
+++ b/style.css
@@ -365,7 +365,7 @@ html,body{height:100%;margin:0;}
     transform: translate(-50%, -100%);
     font-family: var(--brand-font);
     font-size: 1.5vh;
-    width: max-content; /* Dynamic width that prevents wrapping */
+    width: 35vw; /* Wider popup for residual table */
     box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.5); /* Added drop shadow */
 }
 
@@ -396,4 +396,20 @@ html,body{height:100%;margin:0;}
 }
 .popup-close-button:hover {
     color: #ff4081; /* Accent color on hover, or any other suitable hover effect */
+}
+
+/* Table inside popup showing residuals */
+.popup-table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 0.5vh;
+}
+.popup-table th,
+.popup-table td {
+    border: 1px solid white;
+    padding: 0.2vh 0.5vw;
+    font-size: 1.4vh;
+}
+.popup-table th {
+    font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- widen popup for tabular data
- style popup table
- sample PNG layers clientside to estimate value
- compare clicked data from JSON/API with PNG values and show residuals

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_684ec6b37a7c8325a75789e595248bd9