### PR TITLE
Fix powder integration and SQH PNG rendering

### DIFF
--- a/resources/Make TIFs/color_scales.json
+++ b/resources/Make TIFs/color_scales.json
@@ -163,6 +163,19 @@
     "min": 0,
     "max": 360
   },
+  "powder_depth": {
+    "palette": ["rgba(255,255,255,0)", "rgba(255,255,255,1)"],
+    "opacity": true,
+    "min": 0,
+    "max": 100,
+    "interpolation": "linear"
+  },
+  "powder_quality": {
+    "palette": ["#ff0000", "#0000ff", "#ff4081"],
+    "min": 0,
+    "max": 1,
+    "interpolation": "linear"
+  },
   "sqh": {
     "last_updated": "2025-06-15T13:23:00[Europe/Berlin]",
     "palette": [

--- a/resources/Make TIFs/render_pngs.py
+++ b/resources/Make TIFs/render_pngs.py
@@ -66,8 +66,8 @@ def render_sqh_png(depth_tif: pathlib.Path, qual_tif: pathlib.Path, out_png: pat
         depth = dsrc.read(1).astype(float)
         qual = qsrc.read(1).astype(float)
         mask = (depth == dsrc.nodata) | np.isnan(depth)
-        depth_norm = np.clip(depth / 255.0, 0, 1)
-        qual_norm = np.clip((qual / 255.0 - vmin) / (vmax - vmin), 0, 1)
+        depth_norm = np.clip(depth / spec.get("max", 100.0), 0, 1)
+        qual_norm = np.clip((qual - vmin) / (vmax - vmin), 0, 1)
 
     rgba = cmap(qual_norm)
     rgba[..., 3] = depth_norm
@@ -167,8 +167,7 @@ def tif_to_png(tif_path: pathlib.Path):
     with rasterio.open(tif_path) as src:
         data = src.read(1)
         mask = (data == src.nodata) | np.isnan(data)
-        # TIF data is already 0-255, so normalize to 0-1 for colormap
-        norm = np.clip(data / 255.0, 0, 1)
+        norm = np.clip((data.astype(float) - vmin) / (vmax - vmin), 0, 1)
 
     rgba = cmap(norm)
     # Preserve colormap alpha, but set nodata areas to transparent
@@ -223,6 +222,8 @@ def main():
         if ts_dir.name not in TIMESTAMPS:
             continue
         for tif in ts_dir.glob("*.tif"):
+            if tif.stem == "snow_depth":
+                continue
             var = tif.stem  # Get variable name from filename
             png_path = tif.parent / f"{tif.stem}.png"
             if needs_update(tif, png_path, var):


### PR DESCRIPTION
## Summary
- support weather and tif dependency tracking for variables
- implement powder forward integration and SQH helpers
- add topo sort for generation order
- update SQH PNG renderer and skip snow depth
- add colour scales for powder variables

## Testing
- `python -m py_compile resources/'Make TIFs'/generate_tifs_unified.py`
- `python -m py_compile resources/'Make TIFs'/render_pngs.py`


------
https://chatgpt.com/codex/tasks/task_e_684f164fdd908325bd697697d711d76f