### PR TITLE
Optimize TIF generation

### DIFF
--- a/resources/Make TIFs/render_pngs.py
+++ b/resources/Make TIFs/render_pngs.py
@@ -168,12 +168,11 @@ def tif_to_png(tif_path: pathlib.Path):
     print(f"  → {tif_path.relative_to(BASE)} → {png_name} (updating)")
 
     cmap = build_cmap(spec["palette"])
-    vmin, vmax = spec["min"], spec["max"]
 
     with rasterio.open(tif_path) as src:
-        data = src.read(1)
+        data = src.read(1).astype(float)
         mask = (data == src.nodata) | np.isnan(data)
-        norm = np.clip((data.astype(float) - vmin) / (vmax - vmin), 0, 1)
+        norm = np.clip((data - 1) / 254.0, 0, 1)
 
     rgba = cmap(norm)
     # Preserve colormap alpha, but set nodata areas to transparent


### PR DESCRIPTION
## Summary
- cache weather grids per timestamp to avoid storing the entire dataset
- write PNGs using the correct 0-255 scaling

## Testing
- `python -m py_compile resources/Make\ TIFs/generate_tifs.py`
- `python -m py_compile resources/Make\ TIFs/render_pngs.py`


------
https://chatgpt.com/codex/tasks/task_e_684fbb5f35708325a60af4f333f70377